### PR TITLE
キーボードで操作できるようにする

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,6 @@
 module.exports = {
-  extends: [
-    'react-app',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['react-app', 'plugin:prettier/recommended'],
   rules: {
-    'prettier/prettier': ['warn', {
-      singleQuote: true,
-      trailingComma: 'all',
-    }],
+    'prettier/prettier': 'warn',
   },
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'all',
+};

--- a/src/components/AngleSlider.tsx
+++ b/src/components/AngleSlider.tsx
@@ -10,7 +10,8 @@ import styles from './AngleSlider.module.css';
 const formatter = (angle: number) => `${angle.toFixed(1)}°`;
 
 const AngleSlider: React.FC = () => {
-  const hasImage = useSelector(state => Boolean(state.sourceImage.url));
+  const sourceImage = useSelector(state => state.sourceImage);
+  const hasImage = Boolean(sourceImage.url);
 
   const dispatch = useDispatch();
   const onChange = useCallback(
@@ -30,6 +31,7 @@ const AngleSlider: React.FC = () => {
       max={10}
       step={0.1}
       defaultValue={0}
+      value={sourceImage.angle}
       onChange={onChange}
       tipFormatter={formatter}
       tooltipPlacement="bottom"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from 'react';
 import Cropper from 'react-cropper';
 import { useSelector } from 'react-redux';
 
-import { useEnterToCrop } from '../hooks';
+import { useKeyBindings } from '../hooks';
 import Sidebar, { previewClassName } from './Sidebar';
 import { thumbnailPreviewClassName } from './CropList';
 import Canvas from './Canvas';
@@ -15,7 +15,7 @@ const { Content, Sider } = Layout;
 
 const App = () => {
   const cropperRef = useRef<Cropper | null>(null);
-  useEnterToCrop(cropperRef, thumbnailPreviewClassName);
+  useKeyBindings(cropperRef, thumbnailPreviewClassName);
 
   const hasImage = useSelector(state => Boolean(state.sourceImage.url));
 

--- a/src/features/sourceImage.ts
+++ b/src/features/sourceImage.ts
@@ -24,8 +24,20 @@ const slice = createSlice({
     setAngle: (state, action: PayloadAction<number>) => {
       state.angle = action.payload;
     },
+    increaseAngle: (state) => {
+      state.angle = state.angle + 0.1;
+    },
+    decreaseAngle: (state) => {
+      state.angle = state.angle - 0.1;
+    },
   },
 });
 
 export default slice.reducer;
-export const { open, close, setAngle } = slice.actions;
+export const {
+  open,
+  close,
+  setAngle,
+  increaseAngle,
+  decreaseAngle,
+} = slice.actions;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -16,12 +16,29 @@ export const useKeyBindings = (
       if (!cropper) return;
 
       switch (event.key) {
+        // 画像移動
+        case 'ArrowLeft':
+          cropper.move(-1, 0);
+          break;
+        case 'ArrowRight':
+          cropper.move(1, 0);
+          break;
+        case 'ArrowUp':
+          cropper.move(0, -1);
+          break;
+        case 'ArrowDown':
+          cropper.move(0, 1);
+          break;
+
+        // 画像回転
         case 'z':
           dispatch(decreaseAngle());
           break;
         case 'x':
           dispatch(increaseAngle());
           break;
+
+        // 切り抜き
         case 'Enter': {
           const { x, y, width, height, rotate } = cropper.getData();
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,44 +2,60 @@ import { useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { addCrop } from './features/crops';
+import { decreaseAngle, increaseAngle } from './features/sourceImage';
 
-export const useEnterToCrop = (
+export const useKeyBindings = (
   cropperRef: React.MutableRefObject<Cropper | null>,
   thumbnailPreviewClassName: string,
 ): void => {
   const dispatch = useDispatch();
+
   const handler = useCallback(
     (event: KeyboardEvent) => {
       const cropper = cropperRef.current;
-      if (!(cropper && event.key === 'Enter')) return;
-      const { x, y, width, height, rotate } = cropper.getData();
+      if (!cropper) return;
 
-      // 本来であれば cropper.getCropedCanvas() で画像データを直に取得したいところだが、
-      // soruceImage のサイズが大きすぎると、NS_ERROR_FAILURE というエラーが出るなどして、
-      // 取得に失敗することがある。
-      // そこで、サムネイルと同じ大きさのダミーのプレビュー thumbnailPreviewClassName を用意して、
-      // crop 時にそのスタイルを取得し、サムネイル表示に利用するようにする。
-      const divStyle = document.querySelector<HTMLDivElement>(
-        `.${thumbnailPreviewClassName}`,
-      )!.style;
-      const imgStyle = document.querySelector<HTMLImageElement>(
-        `.${thumbnailPreviewClassName}>img`,
-      )!.style;
+      switch (event.key) {
+        case 'z':
+          dispatch(decreaseAngle());
+          break;
+        case 'x':
+          dispatch(increaseAngle());
+          break;
+        case 'Enter': {
+          const { x, y, width, height, rotate } = cropper.getData();
 
-      dispatch(
-        addCrop({
-          params: { x, y, width, height, rotate },
-          divStyle: {
-            width: divStyle.width,
-            height: divStyle.height,
-          },
-          imgStyle: {
-            width: imgStyle.width,
-            height: imgStyle.height,
-            transform: imgStyle.transform,
-          },
-        }),
-      );
+          // 本来であれば cropper.getCropedCanvas() で画像データを直に取得したいところだが、
+          // soruceImage のサイズが大きすぎると、NS_ERROR_FAILURE というエラーが出るなどして、
+          // 取得に失敗することがある。
+          // そこで、サムネイルと同じ大きさのダミーのプレビュー thumbnailPreviewClassName を用意して、
+          // crop 時にそのスタイルを取得し、サムネイル表示に利用するようにする。
+          const divStyle = document.querySelector<HTMLDivElement>(
+            `.${thumbnailPreviewClassName}`,
+          )!.style;
+          const imgStyle = document.querySelector<HTMLImageElement>(
+            `.${thumbnailPreviewClassName}>img`,
+          )!.style;
+
+          dispatch(
+            addCrop({
+              params: { x, y, width, height, rotate },
+              divStyle: {
+                width: divStyle.width,
+                height: divStyle.height,
+              },
+              imgStyle: {
+                width: imgStyle.width,
+                height: imgStyle.height,
+                transform: imgStyle.transform,
+              },
+            }),
+          );
+          break;
+        }
+        default:
+          break;
+      }
     },
     [cropperRef, dispatch, thumbnailPreviewClassName],
   );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,7 +15,7 @@ export const useKeyBindings = (
       const cropper = cropperRef.current;
       if (!cropper) return;
 
-      switch (event.key) {
+      switch (`${event.metaKey ? '⌘' : ''}${event.key}`) {
         // 画像移動
         case 'ArrowLeft':
           cropper.move(-1, 0);
@@ -36,6 +36,28 @@ export const useKeyBindings = (
           break;
         case 'x':
           dispatch(increaseAngle());
+          break;
+
+        // 範囲拡大・縮小
+        case '⌘ArrowLeft':
+          cropper.setCropBoxData({
+            width: cropper.getCropBoxData().width - 1,
+          });
+          break;
+        case '⌘ArrowRight':
+          cropper.setCropBoxData({
+            width: cropper.getCropBoxData().width + 1,
+          });
+          break;
+        case '⌘ArrowUp':
+          cropper.setCropBoxData({
+            height: cropper.getCropBoxData().height - 1,
+          });
+          break;
+        case '⌘ArrowDown':
+          cropper.setCropBoxData({
+            height: cropper.getCropBoxData().height + 1,
+          });
           break;
 
         // 切り抜き


### PR DESCRIPTION
- カーソルキー：画像を移動
- `z`/`x`：画像を回転
- ⌘ カーソルキー：切り抜き範囲のサイズを変更
